### PR TITLE
Increase tinygg2 max buffer size

### DIFF
--- a/bufferflow_tinygg2.go
+++ b/bufferflow_tinygg2.go
@@ -97,7 +97,7 @@ func (b *BufferflowTinygG2) Init() {
 	/* End Slot Approach Items */
 
 	/* Start Buffer Size Approach Items */
-	b.BufferMax = 100 //max buffer size 254 bytes available
+	b.BufferMax = 200 //max buffer size 254 bytes available
 	//b.BufferSize = 0  //initialize buffer at zero bytes
 	b.q = NewQueue()
 	//b.lock = sync.Mutex


### PR DESCRIPTION
May I ask why the max buffer size is set to 100, while a single command can easily be longer than that? For example, this command during init 

```
{"sr":{"line":t,"posx":t,"posy":t,"posz":t,"vel":t,"unit":t,"stat":t,"feed":t,"coor":t,"momo":t,"plan":t,"path":t,"dist":t,"mpox":t,"mpoy":t,"mpoz":t}}
```

Once queued, spjs will stuck forever, and the user will have endless fun with all those yellow ticks.
