### PR TITLE
change JavaScript URLs to https to prevent HTTPS mixed-content errors

### DIFF
--- a/home.html
+++ b/home.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>Serial Port Example</title>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
 <script type="text/javascript">
     $(function() {
 

--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ const homeTemplateHtml = `<!DOCTYPE html>
 <html>
 <head>
 <title>Serial Port Example</title>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
 <script type="text/javascript">
     $(function() {
 


### PR DESCRIPTION
I changed the URLs for the jquery scripts to a https URL.
This prevents mixed-content errors in an https-only environment.