### PR TITLE
Fix issue #27, failed open prevents other open attempts from succeeding

### DIFF
--- a/serialport.go
+++ b/serialport.go
@@ -437,7 +437,8 @@ func spHandlerOpen(portname string, baud int, buftype string, isSecondary bool) 
 		log.Print("Error opening port " + err.Error())
 		//h.broadcastSys <- []byte("Error opening port. " + err.Error())
 		h.broadcastSys <- []byte("{\"Cmd\":\"OpenFail\",\"Desc\":\"Error opening port. " + err.Error() + "\",\"Port\":\"" + conf.Name + "\",\"Baud\":" + strconv.Itoa(conf.Baud) + "}")
-
+		spIsOpening = false
+		spmutex.Unlock()
 		return
 	}
 	log.Print("Opened port successfully")


### PR DESCRIPTION
SPJS forgets to unlock and mutex and reset a flag if it returns due to failing to open a serial port. This PR fixes that code path.