### PR TITLE
closes #42, closes #43, closes #44

### DIFF
--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 type BufferflowGrbl struct {
@@ -98,7 +99,7 @@ func (b *BufferflowGrbl) BlockUntilReady(cmd string, id string) (bool, bool, str
 			return false, false, ""
 		}
 
-		log.Printf("BlockUntilReady(cmd:%v, id:%v) end\n", cmd, id)
+		log.Printf("BlockUntilReady(cmd:%q, id:%v) end\n", cmd, id)
 	}
 	return true, true, ""
 }
@@ -245,6 +246,15 @@ func (b *BufferflowGrbl) BreakApartCommands(cmd string) []string {
 		item = regexp.MustCompile(";.*").ReplaceAllString(item, "")
 		item = strings.Replace(item, " ", "", -1)
 
+		if len(item) > utf8.RuneCountInString(item) {	// If item contains UTF-8 chars other than ASCII. Extended ASCII must be extracted from UTF8 code point
+			r := []rune(item)			// Note : Extended ASCII are used for some realtime commands
+			a := make([]byte, len(r))
+			for idx, element := range r {
+				a[idx] = byte(element)
+        		}
+			item = string(a)
+		}
+		
 		if item == "*init*" { //return init string to update grbl widget when already connected to grbl
 			m := DataPerLine{b.Port, b.version + "\n"}
 			bm, err := json.Marshal(m)
@@ -257,7 +267,7 @@ func (b *BufferflowGrbl) BreakApartCommands(cmd string) []string {
 			if err == nil {
 				h.broadcastSys <- bm
 			}
-		} else if item == "?" {
+		} else if b.SeeIfSpecificCommandsShouldSkipBuffer(item) {	// realtime commands don't need '\n'
 			log.Printf("Query added without newline: %q\n", item)
 			finalCmds = append(finalCmds, item) //append query request without newline character
 		} else if item == "%" {
@@ -265,10 +275,10 @@ func (b *BufferflowGrbl) BreakApartCommands(cmd string) []string {
 			b.LocalBufferWipe(b.parent_serport)
 			//dont add this command to the list of finalCmds
 		} else if item != "" {
-			log.Printf("Re-adding newline to item:%v\n", item)
+			log.Printf("Re-adding newline to item:%q\n", item)
 			s := item + "\n"
 			finalCmds = append(finalCmds, s)
-			log.Printf("New cmd item:%v\n", s)
+			log.Printf("New cmd item:%q\n", s)
 		}
 
 	}
@@ -296,7 +306,7 @@ func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldSkipBuffer(cmd string) bool 
 	//cmd = regexp.MustCompile(";.*").ReplaceAllString(cmd, "")
 	// adding some new regexp to match real-time commands for grbl 1 version 
 	if match, _ := regexp.MatchString("[!~\\?]|(\u0018)|[\u0080-\u00FF]", cmd); match {
-		log.Printf("Found cmd that should skip buffer. cmd:%v\n", cmd)
+		log.Printf("Found cmd that should skip buffer. cmd:%q\n", cmd)
 		return true
 	}
 	return false
@@ -306,22 +316,22 @@ func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldPauseBuffer(cmd string) bool
 	// remove comments
 	//cmd = regexp.MustCompile("\\(.*?\\)").ReplaceAllString(cmd, "")
 	//cmd = regexp.MustCompile(";.*").ReplaceAllString(cmd, "")
-	if match, _ := regexp.MatchString("[!]", cmd); match {
-		log.Printf("Found cmd that should pause buffer. cmd:%v\n", cmd)
-		return true
-	}
-	return false
+	//if match, _ := regexp.MatchString("[!]", cmd); match {
+	//	log.Printf("Found cmd that should pause buffer. cmd:%v\n", cmd)
+	//	return true
+	//}
+	return false	// No commands should stop the transmission
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldUnpauseBuffer(cmd string) bool {
 
 	//cmd = regexp.MustCompile("\\(.*?\\)").ReplaceAllString(cmd, "")
 	//cmd = regexp.MustCompile(";.*").ReplaceAllString(cmd, "")
-	if match, _ := regexp.MatchString("[~]", cmd); match {
-		log.Printf("Found cmd that should unpause buffer. cmd:%v\n", cmd)
-		return true
-	}
-	return false
+	//if match, _ := regexp.MatchString("[~]", cmd); match {
+	//	log.Printf("Found cmd that should unpause buffer. cmd:%v\n", cmd)
+	//	return true
+	//}
+	return false	// No commands should stop the transmission
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldWipeBuffer(cmd string) bool {

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -155,10 +155,9 @@ func (b *BufferflowGrbl) OnIncomingData(data string) {
 					// Send cmd:"Error" back
 					log.Printf("Error Response Received:%v, id:%v", doneCmd, id)
 					arrErrors := strings.SplitN(element, ":", 2)
+					errCode := ""
 					if len(arrErrors) == 2 {
 						errCode := arrErrors[1]
-					} else {
-						errCode := ""
 					}
 					m := DataCmdError{DataCmdComplete{"Error", id, b.Port, b.q.LenOfCmds(), doneCmd}, errCode}
 					bm, err := json.Marshal(m)

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -305,7 +305,7 @@ func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldSkipBuffer(cmd string) bool 
 	//cmd = regexp.MustCompile("\\(.*?\\)").ReplaceAllString(cmd, "")
 	//cmd = regexp.MustCompile(";.*").ReplaceAllString(cmd, "")
 	// adding some new regexp to match real-time commands for grbl 1 version 
-	if match, _ := regexp.MatchString("[!~\\?]|(\u0018)|[\u0080-\u00FF]", cmd); match {
+	if match, _ := regexp.MatchString("[!~\\?]|(\x18)|[\x80-\xFF]", cmd); match {
 		log.Printf("Found cmd that should skip buffer. cmd:%q\n", cmd)
 		return true
 	}

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -36,7 +36,7 @@ type BufferflowGrbl struct {
 	rpt       *regexp.Regexp
 }
 
-type DataCmdError struc {
+type DataCmdError struct {
 	DataCmdComplete
 	ErrorCode	string
 }

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -320,7 +320,7 @@ func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldPauseBuffer(cmd string) bool
 	//	log.Printf("Found cmd that should pause buffer. cmd:%v\n", cmd)
 	//	return true
 	//}
-	return false	// No commands should stop the transmission
+	return false	// No command should stop the transmission
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldUnpauseBuffer(cmd string) bool {
@@ -331,7 +331,7 @@ func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldUnpauseBuffer(cmd string) bo
 	//	log.Printf("Found cmd that should unpause buffer. cmd:%v\n", cmd)
 	//	return true
 	//}
-	return false	// No commands should stop the transmission
+	return false	// No command should stop the transmission
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldWipeBuffer(cmd string) bool {

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -157,7 +157,7 @@ func (b *BufferflowGrbl) OnIncomingData(data string) {
 					arrErrors := strings.SplitN(element, ":", 2)
 					errCode := ""
 					if len(arrErrors) == 2 {
-						errCode := arrErrors[1]
+						errCode = arrErrors[1]
 					}
 					m := DataCmdError{DataCmdComplete{"Error", id, b.Port, b.q.LenOfCmds(), doneCmd}, errCode}
 					bm, err := json.Marshal(m)

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -301,15 +301,18 @@ func (b *BufferflowGrbl) Unpause() {
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldSkipBuffer(cmd string) bool {
+	if len(cmd) != 1 return false		// Skip buffer commands (=realtime commands) are always single byte
+	c := cmd[0]				// Extract ASCII code
+	return c == '!' || c == '~' || c == '?' || c == 0x18 || c >= 0x80 
 	// remove comments
 	//cmd = regexp.MustCompile("\\(.*?\\)").ReplaceAllString(cmd, "")
 	//cmd = regexp.MustCompile(";.*").ReplaceAllString(cmd, "")
 	// adding some new regexp to match real-time commands for grbl 1 version 
-	if match, _ := regexp.MatchString("[!~\\?]|(\x18)|[\x80-\xFF]", cmd); match {
-		log.Printf("Found cmd that should skip buffer. cmd:%q\n", cmd)
-		return true
-	}
-	return false
+	//if match, _ := regexp.MatchString("[!~\\?]|(\u0018)|[\u0080-\u00FF]", cmd); match {
+	//	log.Printf("Found cmd that should skip buffer. cmd:%q\n", cmd)
+	//	return true
+	//}
+	//return false
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldPauseBuffer(cmd string) bool {

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -301,7 +301,9 @@ func (b *BufferflowGrbl) Unpause() {
 }
 
 func (b *BufferflowGrbl) SeeIfSpecificCommandsShouldSkipBuffer(cmd string) bool {
-	if len(cmd) != 1 return false		// Skip buffer commands (=realtime commands) are always single byte
+	if len(cmd) != 1 {		// Skip buffer commands (=realtime commands) are always single byte
+		return false
+	}
 	c := cmd[0]				// Extract ASCII code
 	return c == '!' || c == '~' || c == '?' || c == 0x18 || c >= 0x80 
 	// remove comments

--- a/bufferflow_grbl.go
+++ b/bufferflow_grbl.go
@@ -36,6 +36,11 @@ type BufferflowGrbl struct {
 	rpt       *regexp.Regexp
 }
 
+type DataCmdError struc {
+	DataCmdComplete
+	ErrorCode	string
+}
+
 func (b *BufferflowGrbl) Init() {
 	b.lock = &sync.Mutex{}
 	b.SetPaused(false, 1)
@@ -149,7 +154,13 @@ func (b *BufferflowGrbl) OnIncomingData(data string) {
 				} else if b.err.MatchString(element) {
 					// Send cmd:"Error" back
 					log.Printf("Error Response Received:%v, id:%v", doneCmd, id)
-					m := DataCmdComplete{"Error", id, b.Port, b.q.LenOfCmds(), doneCmd}
+					arrErrors := strings.SplitN(element, ":", 2)
+					if len(arrErrors) == 2 {
+						errCode := arrErrors[1]
+					} else {
+						errCode := ""
+					}
+					m := DataCmdError{DataCmdComplete{"Error", id, b.Port, b.q.LenOfCmds(), doneCmd}, errCode}
 					bm, err := json.Marshal(m)
 					if err == nil {
 						h.broadcastSys <- bm


### PR DESCRIPTION
And :

- Change some %v to %q in Println to get a better view of command contents
- Add a JSON field named ErrorCode to retrieve error issue by Grbl. Now on error the JSON object look like :

```
{"Cmd":"Error","Id":"g4","P":"/dev/ttyUSB2","ErrorCode":"20"}
                                           ^^^^^^^^^^^^^^^^^
```